### PR TITLE
Update 5_Distributed_preprocessing.ipynb

### DIFF
--- a/5_Distributed_preprocessing.ipynb
+++ b/5_Distributed_preprocessing.ipynb
@@ -150,8 +150,8 @@
     "\n",
     "if not os.path.exists(workspace_path):\n",
     "    os.mkdir(workspace_path)\n",
-    "else:\n",
-    "    cfg.PATHS['working_dir'] = workspace_path"
+    "\n",
+    "cfg.PATHS['working_dir'] = workspace_path"
    ]
   },
   {
@@ -319,7 +319,7 @@
     "    tasks.gridded_mb_attributes,\n",
     "]\n",
     "for task in task_list:\n",
-    "    workflow.execute_entity_task(task, gdirs)"
+    "    workflow.execute_entity_task(task, gdirs, print_log=False)"
    ]
   },
   {


### PR DESCRIPTION
Two small changes in the notebook.

First, when defining the working directory the else should be deleted. Because if the directory does not exist it will be created but `cfg.PATHS['working_dir']` will not be set.

Second, I included `print_log=False` to suppress the error messages (which flood the output cell).